### PR TITLE
Make pins same as schematics state in page

### DIFF
--- a/OsciCam/Pins.h
+++ b/OsciCam/Pins.h
@@ -29,7 +29,7 @@ const int D3 = 15;
 const int D4 = 14;
 const int D5 = 13;
 const int D6 = 12;
-const int D7 = 4;;
+const int D7 = 4;
 
 const int TFT_DC = 2;
 const int TFT_CS = 5;

--- a/OsciCam/Pins.h
+++ b/OsciCam/Pins.h
@@ -22,14 +22,14 @@ const int HREF = 35;
 const int XCLK = 32;
 const int PCLK = 33;
 
-const int D0 = 15;
-const int D1 = 13;
-const int D2 = 4;
-const int D3 = 14;
-const int D4 = 12;
-const int D5 = 16;
-const int D6 = 27;
-const int D7 = 17;
+const int D0 = 27;
+const int D1 = 17;
+const int D2 = 16;
+const int D3 = 15;
+const int D4 = 14;
+const int D5 = 13;
+const int D6 = 12;
+const int D7 = 4;;
 
 const int TFT_DC = 2;
 const int TFT_CS = 5;


### PR DESCRIPTION
In your home page, you reference your SPI camera schematics as tutorial, but pin definitions differ on OsciDisplay project. Made the same as SPI camera project, this should minimize problems, for users, that want to test before tinkering with the source :)