### PR TITLE
Add stdlib.h include

### DIFF
--- a/OsciCam/DMABuffer.h
+++ b/OsciCam/DMABuffer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "stdlib.h"
 
 class DMABuffer
 {


### PR DESCRIPTION
malloc that is used in DMABuffer.c comes from stdlib.h. At least with PlatformIO and vscode it fails to build without this. And on arduino ide it should make a difference